### PR TITLE
Allow compute capabilities newer than the compiled version.

### DIFF
--- a/src/kmcuda.cc
+++ b/src/kmcuda.cc
@@ -83,7 +83,8 @@ static std::vector<int> setup_devices(uint32_t device, int device_ptrs, int verb
              dev, cudaGetErrorString(err));
         devs.pop_back();
       }
-      if (props.major != (CUDA_ARCH / 10) || props.minor != (CUDA_ARCH % 10)) {
+      if (props.major < (CUDA_ARCH / 10) ||
+          (props.major == (CUDA_ARCH / 10) && props.minor < (CUDA_ARCH % 10))) {
         INFO("compute capability mismatch for device %d: wanted %d.%d, have "
              "%d.%d\n>>>> you may want to build kmcuda with -DCUDA_ARCH=%d "
              "(refer to \"Building\" in README.md)\n",


### PR DESCRIPTION
Given that the specified compute capability is passed to `nvcc` via `-arch sm_${CUDA_ARCH}` in the [`CMakeLists.txt`](https://github.com/src-d/kmcuda/blob/32587387804b19b18fc653874594cd93c04d2b46/src/CMakeLists.txt#L50) during the build, the compiled CUDA kernels have real binaries for that specific architecture and PTX binaries for the same compute architecture, allowing for JIT dynamic compilation on newer architectures (see https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-steering-gpu-code-generation). Therefore the compute capability check should only exclude versions that are older than specified compute capability rather than allowing only exact matches.